### PR TITLE
experimental: reduce calls to serial port write

### DIFF
--- a/ThermalTalk/IPrinter.cs
+++ b/ThermalTalk/IPrinter.cs
@@ -117,7 +117,7 @@ namespace ThermalTalk
         /// Print string as ASCII text. Any effects that are currently
         /// active will be applied to this string.
         /// </summary>
-        /// <param name="str">ASCII stirng to print</param>
+        /// <param name="str">ASCII string to print</param>
         ReturnCode PrintASCIIString(string str);
 
         /// <summary>

--- a/ThermalTalk/Phoenix/PhoenixPrinter.cs
+++ b/ThermalTalk/Phoenix/PhoenixPrinter.cs
@@ -133,7 +133,7 @@ namespace ThermalTalk
             var printit = new byte[] {0x1D, 0x28, 0x6B, 0x03, 0x00, 0x31, 0x51, 0x31};
 
             var fullCmd = Extensions.Concat(setup, Encoding.ASCII.GetBytes(encodeThis), printit);
-            return internalSend(fullCmd);
+            return AppendToDocBuffer(fullCmd);
         }
 
         /// <summary>
@@ -158,15 +158,15 @@ namespace ThermalTalk
             {
                 case ThermalFonts.A:
                     Logger?.Trace("Attempting to set font to font A.");
-                    result =  internalSend(FontACmd);
+                    result =  AppendToDocBuffer(FontACmd);
                     break;
                 case ThermalFonts.B:
                     Logger?.Trace("Attempting to set font to font B.");
-                    result = internalSend(FontBCmd);
+                    result = AppendToDocBuffer(FontBCmd);
                     break;
                 case ThermalFonts.C:
                     Logger?.Trace("Attempting to set font to font C.");
-                    result =  internalSend(FontCCmd);
+                    result =  AppendToDocBuffer(FontCCmd);
                     break;
             }
 

--- a/ThermalTalk/Reliance/ReliancePrinter.cs
+++ b/ThermalTalk/Reliance/ReliancePrinter.cs
@@ -129,15 +129,15 @@ namespace ThermalTalk
             {
                 case ThermalFonts.A:
                     Logger?.Trace("Attempting to set font to font CPI11.");
-                    result = internalSend(CPI11);
+                    result = AppendToDocBuffer(CPI11);
                     break;
                 case ThermalFonts.B:
                     Logger?.Trace("Attempting to set font to font CPI15.");
-                    result = internalSend(CPI15);
+                    result = AppendToDocBuffer(CPI15);
                     break;
                 case ThermalFonts.C:
                     Logger?.Trace("Attempting to set font to font CPI20.");
-                    result = internalSend(CPI20);
+                    result = AppendToDocBuffer(CPI20);
                     break;
 
             }
@@ -161,7 +161,7 @@ namespace ThermalTalk
             var setup = new byte[] { 0x0A, 0x1C, 0x7D, 0x25, (byte)len };
 
             var fullCmd = Extensions.Concat(setup, Encoding.ASCII.GetBytes(encodeThis), new byte[] { 0x0A });
-            return internalSend(fullCmd);
+            return AppendToDocBuffer(fullCmd);
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace ThermalTalk
             var payload = barcode.Build();
             if (payload.Length > 0)
             {
-                return internalSend(payload);
+                return AppendToDocBuffer(payload);
             }
 
             Logger?.Error("barcode.Build() has length 0.");


### PR DESCRIPTION
In this changeset we are attempting to reduce the amount of calls to the
serial port write function. The idea is to build up the document in a buffer
backed by a MemoryStream stream. Then, on FormFeed, we will write the
entire buffer to the printer in one operation.

What do you think of this approach?