### PR TITLE
V1.5.0.0 reduce write calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
+# 1.5
+**bug fixes**
+* None
+
+*New*
+* Added document buffer for storing ESC/POS prior to writing to port
+
 # 1.4
-** bug fixes **
+**bug fixes**
 * Fixed IsTicketPresentAtOutput flag parse
 * Fixed HasError flag parse
 * Fixed HasFatalError flag parse
 * Fixed HasRecoverableError flag parse
 
-* New *
+*New*
 * Does not assume webcam number in CLI example project
 
 # 1.3

--- a/ThermalTalk/Common/BasePrinter.cs
+++ b/ThermalTalk/Common/BasePrinter.cs
@@ -29,12 +29,21 @@ namespace ThermalTalk
     using System.Collections.Generic;
     using System.Text;
     using ThermalTalk.Imaging;
+    using System.IO;
 
-    /// <inheritdoc />
+    /// <summary>
+    /// A buffered printing interface that builds a document in memory. This document is referred to
+    /// as the document buffer. To print your document buffer, call <see cref="FormFeed"/>.
+    /// </summary>
     [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
     public abstract class BasePrinter : IPrinter
     {
-        /// <inheritdoc />
+        protected MemoryStream _stream;
+        protected BinaryWriter _docBuffer;
+
+        /// <summary>
+        /// Initialize common printer properties
+        /// </summary>
         protected BasePrinter()
         {
             Justification = FontJustification.JustifyLeft;
@@ -42,6 +51,9 @@ namespace ThermalTalk
             InitPrinterCommand = new byte[0];
             FormFeedCommand = new byte[0];
             NewLineCommand = new byte[0];
+
+            _stream = new MemoryStream();
+            _docBuffer = new BinaryWriter(_stream);
         }
 
         /// <summary>
@@ -70,9 +82,11 @@ namespace ThermalTalk
         protected byte[] InitPrinterCommand { get; set; }
 
         /// <summary>
-        /// Command sent to execute a newline and print job
-        /// Leave empty if not supported.
+        /// Writes document buffer to printer and clears the print buffer.
         /// </summary>
+        /// <returns><see cref="ReturnCode.UnsupportedCommand"/> if the document buffer is empty.
+        /// If the document fails to transmit, <see cref="ReturnCode.ExecutionFailure"/> is returned.
+        /// Otherwise, <see cref="ReturnCode.Success"/></returns>
         protected byte[] FormFeedCommand { get; set; }
 
         /// <summary>
@@ -93,7 +107,7 @@ namespace ThermalTalk
         protected Dictionary<FontEffects, byte[]> DisableCommands { get; set; }
 
         /// <summary>
-        /// Map justifcation commands and the specific byte command to apply them
+        /// Map justification commands and the specific byte command to apply them
         /// </summary>
         protected Dictionary<FontJustification, byte[]> JustificationCommands { get; set; }
 
@@ -135,7 +149,7 @@ namespace ThermalTalk
 
         /// <summary>
         /// Encodes the specified string as a center justified 2D barcode. 
-        /// This 2D barcode is compliant with the QR Code® specicification and can be read by all 2D barcode readers.
+        /// This 2D barcode is compliant with the QR Code® specification and can be read by all 2D barcode readers.
         /// </summary>
         /// <param name="encodeThis">String to encode</param>
         public abstract void Print2DBarcode(string encodeThis);    
@@ -167,7 +181,7 @@ namespace ThermalTalk
             Height = FontHeighScalar.h1;
             Effects = FontEffects.None;
 
-            internalSend(InitPrinterCommand);
+            AppendToDocBuffer(InitPrinterCommand);
         }
 
         /// <inheritdoc />
@@ -195,7 +209,7 @@ namespace ThermalTalk
             byte[] cmd = (byte[])SetScalarCommand.Clone();
 
             cmd[2] = (byte)(wb | hb);
-            internalSend(cmd);
+            AppendToDocBuffer(cmd);
         }
 
         /// <inheritdoc />
@@ -218,7 +232,7 @@ namespace ThermalTalk
                 byte[] cmd = JustificationCommands[justification];
                 if (cmd != null)
                 {
-                    internalSend(cmd);
+                    AppendToDocBuffer(cmd);
                 }
             }
         }
@@ -236,7 +250,7 @@ namespace ThermalTalk
                 var cmd = EnableCommands[flag];
                 if (cmd.Length > 0)
                 {
-                    internalSend(cmd);
+                    AppendToDocBuffer(cmd);
                 }
             }
 
@@ -254,7 +268,7 @@ namespace ThermalTalk
                     var cmd = DisableCommands[flag];
                     if (cmd.Length > 0)
                     {
-                        internalSend(cmd);
+                        AppendToDocBuffer(cmd);
                     }
                 }
             }
@@ -268,7 +282,7 @@ namespace ThermalTalk
             {
                 if (cmd.Length > 0)
                 {
-                    internalSend(cmd);
+                    AppendToDocBuffer(cmd);
                 }
             }
             Effects = FontEffects.None;
@@ -277,7 +291,7 @@ namespace ThermalTalk
         /// <inheritdoc />
         public virtual void PrintASCIIString(string str)
         {
-            internalSend(Encoding.ASCII.GetBytes(str));
+            AppendToDocBuffer(Encoding.ASCII.GetBytes(str));
         }
 
         /// <inheritdoc />
@@ -301,7 +315,7 @@ namespace ThermalTalk
                 SetFont(sec.Font);
 
                 // Send the actual content
-                internalSend(sec.GetContentBuffer(doc.CodePage));
+                AppendToDocBuffer(sec.GetContentBuffer(doc.CodePage));
 
                 if (sec.AutoNewline)
                 {
@@ -324,19 +338,48 @@ namespace ThermalTalk
         /// <inheritdoc />
         public virtual void PrintNewline()
         {
-            internalSend(NewLineCommand);
+            AppendToDocBuffer(NewLineCommand);
         }
 
         /// <inheritdoc />
-        public virtual void FormFeed()
+        public virtual ReturnCode FormFeed()
         {
-            internalSend(FormFeedCommand);
+            AppendToDocBuffer(FormFeedCommand);
+            
+            var payload = _stream.ToArray();
+            
+            // Do not send empty packets
+            if (payload.Length == 0)
+            {
+                return ReturnCode.UnsupportedCommand;
+            }
+            
+            try
+            {
+                Connection.Open();
+                Connection.Write(payload);
+                
+                return ReturnCode.Success;
+            }
+            catch(Exception e)
+            {
+                return ReturnCode.ExecutionFailure;
+            }
+            finally
+            {
+                // BinaryWriter closes the underlying stream on dispose 
+                _docBuffer.Dispose();
+                _stream = new MemoryStream();
+                _docBuffer = new BinaryWriter(_stream);
+                
+                Connection.Close();
+            }
         }
 
         /// <inheritdoc />
         public virtual void SendRaw(byte[] raw)
         {
-            internalSend(raw);
+            AppendToDocBuffer(raw);
         }
 
 
@@ -350,41 +393,28 @@ namespace ThermalTalk
         /// <summary>
         /// Close serial connection
         /// </summary>
-        /// <param name="diposing">True to close connection</param>
+        /// <param name="disposing">True to close connection</param>
         protected virtual void Dispose(bool diposing)
         {
             if (Connection != null)
             {
                 Connection.Dispose();
             }
+
+            _docBuffer.Dispose();
         }
 
         #region Protected
         /// <summary>
-        /// Send payload over serial port. If port
-        /// is not open, this will open the port before writing.
-        /// The port will be closed when the write completes or fails.
+        /// Append print command data to the end of the current document.
+        /// Document is not actually printed until <see cref="FormFeed"/> is called.
         /// </summary>
         /// <param name="payload"></param>
-        protected void internalSend(byte[] payload)
+        /// <returns>ReturnCode.Success if successful, ReturnCode.UnsupportedCommand if payload.Length == 0, and ReturnCode.ExecutionFailure otherwise.</returns>
+        protected ReturnCode AppendToDocBuffer(byte[] payload)
         {
-            // Do not send empty packets
-            if (payload.Length == 0)
-            {
-                return;
-            }
-
-            try
-            {
-                Connection.Open();
-
-                Connection.Write(payload);
-            }
-            catch { /* Do nothing */ }
-            finally
-            {
-                Connection.Close();
-            }
+            _docBuffer.Write(payload);
+            return ReturnCode.Success;
         }
         #endregion
     }

--- a/ThermalTalk/Common/BasePrinter.cs
+++ b/ThermalTalk/Common/BasePrinter.cs
@@ -413,6 +413,16 @@ namespace ThermalTalk
         /// <returns>ReturnCode.Success if successful, ReturnCode.UnsupportedCommand if payload.Length == 0, and ReturnCode.ExecutionFailure otherwise.</returns>
         protected ReturnCode AppendToDocBuffer(byte[] payload)
         {
+            if (payload is null)
+            {
+                return ReturnCode.ExecutionFailure;
+            }
+
+            if (payload.Length == 0)
+            {
+                return ReturnCode.UnsupportedCommand;
+            }
+            
             _docBuffer.Write(payload);
             return ReturnCode.Success;
         }

--- a/ThermalTalk/IPrinter.cs
+++ b/ThermalTalk/IPrinter.cs
@@ -156,8 +156,10 @@ namespace ThermalTalk
 
         /// <summary>
         /// Mark ticket as complete and present
+        /// This function transmit the current document buffer to the printer
+        /// then clears the document buffer.
         /// </summary>
-        void FormFeed();
+        ReturnCode FormFeed();
 
         /// <summary>
         /// Send raw buffer to target printer.

--- a/ThermalTalk/Phoenix/PhoenixPrinter.cs
+++ b/ThermalTalk/Phoenix/PhoenixPrinter.cs
@@ -131,7 +131,7 @@ namespace ThermalTalk
             var printit = new byte[] {0x1D, 0x28, 0x6B, 0x03, 0x00, 0x31, 0x51, 0x31};
 
             var fullCmd = Extensions.Concat(setup, Encoding.ASCII.GetBytes(encodeThis), printit);
-            internalSend(fullCmd);
+            AppendToDocBuffer(fullCmd);
         }
 
         /// <summary>
@@ -148,13 +148,13 @@ namespace ThermalTalk
             switch (font)
             {
                 case ThermalFonts.A:
-                    internalSend(FontACmd);
+                    AppendToDocBuffer(FontACmd);
                     break;
                 case ThermalFonts.B:
-                    internalSend(FontBCmd);
+                    AppendToDocBuffer(FontBCmd);
                     break;
                 case ThermalFonts.C:
-                    internalSend(FontCCmd);
+                    AppendToDocBuffer(FontCCmd);
                     break;
             }
         }

--- a/ThermalTalk/Properties/AssemblyInfo.cs
+++ b/ThermalTalk/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0.0")]
-[assembly: AssemblyFileVersion("1.4.0.0")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]

--- a/ThermalTalk/Reliance/ReliancePrinter.cs
+++ b/ThermalTalk/Reliance/ReliancePrinter.cs
@@ -123,13 +123,13 @@ namespace ThermalTalk
             switch (font)
             {
                 case ThermalFonts.A:
-                    internalSend(CPI11);
+                    AppendToDocBuffer(CPI11);
                     break;
                 case ThermalFonts.B:
-                    internalSend(CPI15);
+                    AppendToDocBuffer(CPI15);
                     break;
                 case ThermalFonts.C:
-                    internalSend(CPI20);
+                    AppendToDocBuffer(CPI20);
                     break;
             }
         }
@@ -149,7 +149,7 @@ namespace ThermalTalk
             var setup = new byte[] { 0x0A, 0x1C, 0x7D, 0x25, (byte)len };
 
             var fullCmd = Extensions.Concat(setup, Encoding.ASCII.GetBytes(encodeThis), new byte[] { 0x0A });
-            internalSend(fullCmd);
+            AppendToDocBuffer(fullCmd);
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace ThermalTalk
             var payload = barcode.Build();
             if (payload.Length > 0)
             {
-                internalSend(payload);
+                AppendToDocBuffer(payload);
             }
         }
 


### PR DESCRIPTION
[AP-160] Port reduce write calls fixes to 1.x branch

Add document buffer to BasePrinter. This will store ESC/POS bytes until a form feed command is sent, reducing the number of write calls to the port.


v1.5.0.0 branch will hold our feature frozen version of ThermalTalk supporting net40.
master branch will be version 2.0.0.0 of Thermaltalk and will be bumped to net45, netstandard2.0, net5 in subsequent PRs. 

[AP-160]: https://pyramid.atlassian.net/browse/AP-160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ