### PR TITLE
Barcode section support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.1.0.0
+** bug fixes **
+* None
+
+* New *
+* Add BarcodeSection and TwoD barcode type
+
 # 2.0.1.0
 ** bug fixes **
 * #12 Phoenix OffLineStatus corrected

--- a/ThermalConsole/Program.cs
+++ b/ThermalConsole/Program.cs
@@ -132,7 +132,7 @@ namespace ThermalConsole
                     printer.SetImage(image, document, 1);
                     
                     // Update barcode
-                    var barcode = new TwoD(TwoD.Flavor.Phoenix)
+                    var barcode = new TwoDBarcode(TwoDBarcode.Flavor.Phoenix)
                     {
                         EncodeThis = $"There have been {count} prints"
                     };

--- a/ThermalConsole/Program.cs
+++ b/ThermalConsole/Program.cs
@@ -93,6 +93,7 @@ namespace ThermalConsole
 
             document.Sections.Add(header);
             document.Sections.Add(new Placeholder());  // Placeholder since we know we'll want an image here
+            document.Sections.Add(new Placeholder());  // Placeholder since we know we'll want a barcode here
             document.Sections.Add(timestamp);
             document.Sections.Add(printStatus);
 
@@ -129,6 +130,13 @@ namespace ThermalConsole
 
                     // Re-assign this image to the middle part of the document
                     printer.SetImage(image, document, 1);
+                    
+                    // Update barcode
+                    var barcode = new TwoD(TwoD.Flavor.Phoenix)
+                    {
+                        EncodeThis = $"There have been {count} prints"
+                    };
+                    printer.SetBarcode(barcode, document, 2);
 
                     // Send the whole document + image
                     printer.PrintDocument(document);

--- a/ThermalTalk/Barcodes/BarcodeTypes.cs
+++ b/ThermalTalk/Barcodes/BarcodeTypes.cs
@@ -22,5 +22,9 @@ namespace ThermalTalk
         /// Supported since 1.21 firmware
         /// </summary>
         ITF,
+        /// <summary>
+        /// 2D barcode generator
+        /// </summary>
+        TwoD
     }
 }

--- a/ThermalTalk/Barcodes/TwoD.cs
+++ b/ThermalTalk/Barcodes/TwoD.cs
@@ -1,0 +1,98 @@
+﻿namespace ThermalTalk
+{
+    using System.Text;
+
+    /// <summary>
+    /// General 2D barcode
+    /// </summary>
+    public class TwoD : IBarcode
+    {
+        /// <summary>
+        /// 2D barcode flavor
+        /// </summary>
+        public enum Flavor
+        {
+            /// <summary>
+            ///     Phoenix style
+            /// </summary>
+            Phoenix,
+
+            /// <summary>
+            ///     Reliance style
+            /// </summary>
+            Reliance
+        }
+
+        private readonly Flavor _flavor;
+
+        /// <summary>
+        /// Create a new 2D barcode
+        /// Note that Phoenix and Reliance 2D barcodes are slightly different
+        /// so you must specify the flavor parameter.
+        /// </summary>
+        /// <param name="flavor">Printer flavor</param>
+        public TwoD(Flavor flavor)
+        {
+            _flavor = flavor;
+        }
+
+        /// <inheritdoc />
+        public string EncodeThis { get; set; }
+
+        /// <inheritdoc />
+        public byte Form { get; set; }
+
+        /// <inheritdoc />
+        public byte BarcodeDotHeight { get; set; }
+
+        /// <inheritdoc />
+        public byte BarcodeWidthMultiplier { get; set; }
+
+        /// <inheritdoc />
+        public HRIPositions HriPosition { get; set; }
+
+        /// <inheritdoc />
+        public ThermalFonts BarcodeFont { get; set; }
+
+        /// <inheritdoc />
+        public byte[] Build()
+        {
+            switch (_flavor)
+            {
+                case Flavor.Phoenix:
+                    return BuildPhoenixFlavor();
+                case Flavor.Reliance:
+                    return BuildRelianceFlavor();
+                default:
+                    return new byte[0];
+            }
+        }
+
+        /// <summary>
+        /// Build 2D barcode using Phoenix syntax
+        /// </summary>
+        /// <returns>2D barcode generator command</returns>
+        private byte[] BuildPhoenixFlavor()
+        {
+            var len = EncodeThis.Length > 154 ? 154 : EncodeThis.Length;
+            var setup = new byte[] { 0x1D, 0x28, 0x6B, (byte)len, 0x00, 0x31, 0x50 };
+            var printIt = new byte[] { 0x1D, 0x28, 0x6B, 0x03, 0x00, 0x31, 0x51, 0x31 };
+
+            var fullCmd = Extensions.Concat(setup, Encoding.ASCII.GetBytes(EncodeThis), printIt);
+            return fullCmd;
+        }
+
+        /// <summary>
+        /// Build 2D barcode using Reliance syntax
+        /// </summary>
+        /// <returns>2D barcode generator command</returns>
+        private byte[] BuildRelianceFlavor()
+        {
+            var len = EncodeThis.Length > 154 ? 154 : EncodeThis.Length;
+            var setup = new byte[] { 0x0A, 0x1C, 0x7D, 0x25, (byte)len };
+
+            var fullCmd = Extensions.Concat(setup, Encoding.ASCII.GetBytes(EncodeThis), new byte[] { 0x0A });
+            return fullCmd;
+        }
+    }
+}

--- a/ThermalTalk/Barcodes/TwoDBarcode.cs
+++ b/ThermalTalk/Barcodes/TwoDBarcode.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// General 2D barcode
     /// </summary>
-    public class TwoD : IBarcode
+    public class TwoDBarcode : IBarcode
     {
         /// <summary>
         /// 2D barcode flavor
@@ -31,7 +31,7 @@
         /// so you must specify the flavor parameter.
         /// </summary>
         /// <param name="flavor">Printer flavor</param>
-        public TwoD(Flavor flavor)
+        public TwoDBarcode(Flavor flavor)
         {
             _flavor = flavor;
         }

--- a/ThermalTalk/Common/BasePrinter.cs
+++ b/ThermalTalk/Common/BasePrinter.cs
@@ -393,6 +393,19 @@ namespace ThermalTalk
         public abstract ReturnCode SetImage(PrinterImage image, IDocument doc, int index);
 
         /// <inheritdoc />
+        public ReturnCode SetBarcode(IBarcode barcode, IDocument doc, int index)
+        {
+            while (index > doc.Sections.Count)
+            {
+                doc.Sections.Add(new Placeholder());
+            }
+
+            doc.Sections[index] = new BarcodeSection(barcode);
+
+            return ReturnCode.Success;
+        }
+
+        /// <inheritdoc />
         public virtual ReturnCode PrintNewline()
         {
             Logger?.Trace("Printing new line . . . ");

--- a/ThermalTalk/Common/BasePrinter.cs
+++ b/ThermalTalk/Common/BasePrinter.cs
@@ -395,7 +395,7 @@ namespace ThermalTalk
         /// <inheritdoc />
         public ReturnCode SetBarcode(IBarcode barcode, IDocument doc, int index)
         {
-            while (index > doc.Sections.Count)
+            while (index >= doc.Sections.Count)
             {
                 doc.Sections.Add(new Placeholder());
             }

--- a/ThermalTalk/IPrinter.cs
+++ b/ThermalTalk/IPrinter.cs
@@ -162,7 +162,7 @@ namespace ThermalTalk
         ReturnCode SetImage(PrinterImage image, IDocument doc, int index);
 
         /// <summary>
-        /// Sets this logo to a position inside doc specified by index.    
+        /// Sets this barcode to a position inside doc specified by index.    
         /// </summary>
         /// <param name="barcode">Barcode to add</param>
         /// <param name="doc">Receives barcode</param>

--- a/ThermalTalk/IPrinter.cs
+++ b/ThermalTalk/IPrinter.cs
@@ -1,4 +1,5 @@
 ﻿#region Copyright & License
+
 /*
 MIT License
 
@@ -22,7 +23,9 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
+
 #endregion
+
 namespace ThermalTalk
 {
     using ThermalTalk.Imaging;
@@ -56,7 +59,7 @@ namespace ThermalTalk
         /// Gets the active font
         /// </summary>
         ThermalFonts Font { get; }
-        
+
         /// <summary>
         /// Gets or set the logger for IPrinter
         /// </summary>
@@ -157,6 +160,16 @@ namespace ThermalTalk
         /// placeholders will be inserted until index is reached.</param>
         /// <returns>ReturnCode.Success if successful, ReturnCode.ExecutionFailure otherwise</returns>
         ReturnCode SetImage(PrinterImage image, IDocument doc, int index);
+
+        /// <summary>
+        /// Sets this logo to a position inside doc specified by index.    
+        /// </summary>
+        /// <param name="barcode">Barcode to add</param>
+        /// <param name="doc">Receives barcode</param>
+        /// <param name="index">Index to insert. If this index exceeds the current length
+        /// placeholders will be inserted until index is reached.</param>
+        /// <returns>ReturnCode.Success if successful, ReturnCode.ExecutionFailure otherwise</returns>
+        ReturnCode SetBarcode(IBarcode barcode, IDocument doc, int index);
 
         /// <summary>
         /// Emit one newline character and return print

--- a/ThermalTalk/Phoenix/PhoenixPrinter.cs
+++ b/ThermalTalk/Phoenix/PhoenixPrinter.cs
@@ -127,12 +127,13 @@ namespace ThermalTalk
         public override ReturnCode Print2DBarcode(string encodeThis)
         {
             Logger?.Trace("Encoding the following string as a barcode: " + encodeThis);
-            
-            var len = encodeThis.Length > 154 ? 154 : encodeThis.Length;
-            var setup = new byte[] { 0x1D, 0x28, 0x6B, (byte)len, 0x00, 0x31, 0x50 };
-            var printit = new byte[] {0x1D, 0x28, 0x6B, 0x03, 0x00, 0x31, 0x51, 0x31};
 
-            var fullCmd = Extensions.Concat(setup, Encoding.ASCII.GetBytes(encodeThis), printit);
+            // Use all default values for barcode
+            var barcode = new TwoD(TwoD.Flavor.Phoenix)
+            {
+                EncodeThis = encodeThis
+            };
+            var fullCmd = barcode.Build();
             return AppendToDocBuffer(fullCmd);
         }
 
@@ -176,9 +177,10 @@ namespace ThermalTalk
         /// <summary>
         /// TODO: Phoenix does not currently supports ESC/POS images at this time.
         /// </summary>
-        /// <param name="image"></param>
-        /// <param name="doc"></param>
-        /// <param name="index"></param>
+        /// <param name="image">Image to add</param>
+        /// <param name="doc">Document to add</param>
+        /// <param name="index">Index to insert. If this index exceeds the current length
+        /// placeholders will be inserted until index is reached.</param>
         /// <returns>ReturnCode.Success if successful, ReturnCode.ExecutionFailure otherwise.</returns>
         public override ReturnCode SetImage(PrinterImage image, IDocument doc, int index)
         {

--- a/ThermalTalk/Phoenix/PhoenixPrinter.cs
+++ b/ThermalTalk/Phoenix/PhoenixPrinter.cs
@@ -129,7 +129,7 @@ namespace ThermalTalk
             Logger?.Trace("Encoding the following string as a barcode: " + encodeThis);
 
             // Use all default values for barcode
-            var barcode = new TwoD(TwoD.Flavor.Phoenix)
+            var barcode = new TwoDBarcode(TwoDBarcode.Flavor.Phoenix)
             {
                 EncodeThis = encodeThis
             };

--- a/ThermalTalk/Phoenix/PhoenixPrinter.cs
+++ b/ThermalTalk/Phoenix/PhoenixPrinter.cs
@@ -184,7 +184,7 @@ namespace ThermalTalk
         /// <returns>ReturnCode.Success if successful, ReturnCode.ExecutionFailure otherwise.</returns>
         public override ReturnCode SetImage(PrinterImage image, IDocument doc, int index)
         {
-            while (index > doc.Sections.Count)
+            while (index >= doc.Sections.Count)
             {
                 doc.Sections.Add(new Placeholder());
             }

--- a/ThermalTalk/Reliance/ReliancePrinter.cs
+++ b/ThermalTalk/Reliance/ReliancePrinter.cs
@@ -190,7 +190,7 @@ namespace ThermalTalk
         /// <inheritdoc />
         public override ReturnCode SetImage(PrinterImage image, IDocument doc, int index)
         {
-            while(index > doc.Sections.Count)
+            while(index >= doc.Sections.Count)
             {
                 doc.Sections.Add(new Placeholder());
             }

--- a/ThermalTalk/Reliance/ReliancePrinter.cs
+++ b/ThermalTalk/Reliance/ReliancePrinter.cs
@@ -158,7 +158,7 @@ namespace ThermalTalk
         public override ReturnCode Print2DBarcode(string encodeThis)
         {
             // Use all default values for barcode
-            var barcode = new TwoD(TwoD.Flavor.Reliance)
+            var barcode = new TwoDBarcode(TwoDBarcode.Flavor.Reliance)
             {
                 EncodeThis = encodeThis
             };

--- a/ThermalTalk/Reliance/ReliancePrinter.cs
+++ b/ThermalTalk/Reliance/ReliancePrinter.cs
@@ -157,10 +157,12 @@ namespace ThermalTalk
         /// <returns>ReturnCode.Success if successful, ReturnCode.ExecutionFailure otherwise.</returns>
         public override ReturnCode Print2DBarcode(string encodeThis)
         {
-            var len = encodeThis.Length > 154 ? 154 : encodeThis.Length;
-            var setup = new byte[] { 0x0A, 0x1C, 0x7D, 0x25, (byte)len };
-
-            var fullCmd = Extensions.Concat(setup, Encoding.ASCII.GetBytes(encodeThis), new byte[] { 0x0A });
+            // Use all default values for barcode
+            var barcode = new TwoD(TwoD.Flavor.Reliance)
+            {
+                EncodeThis = encodeThis
+            };
+            var fullCmd = barcode.Build();
             return AppendToDocBuffer(fullCmd);
         }
 

--- a/ThermalTalk/Templates/BarcodeSection.cs
+++ b/ThermalTalk/Templates/BarcodeSection.cs
@@ -1,0 +1,46 @@
+﻿namespace ThermalTalk
+{
+    /// <summary>
+    /// Create a new barcode section
+    /// </summary>
+    public class BarcodeSection : ISection
+    {
+        private readonly IBarcode _barcode;
+
+        /// <summary>
+        /// Create a new section using the specified barcode
+        /// </summary>
+        /// <param name="barcode"></param>
+        public BarcodeSection(IBarcode barcode)
+        {
+            _barcode = barcode;
+        }
+
+        /// <inheritdoc />
+        public string Content { get; set; }
+
+        /// <inheritdoc />
+        public FontEffects Effects { get; set; }
+
+        /// <inheritdoc />
+        public FontJustification Justification { get; set; }
+
+        /// <inheritdoc />
+        public FontWidthScalar WidthScalar { get; set; }
+
+        /// <inheritdoc />
+        public FontHeighScalar HeightScalar { get; set; }
+
+        /// <inheritdoc />
+        public ThermalFonts Font { get; set; }
+
+        /// <inheritdoc />
+        public bool AutoNewline { get; set; }
+
+        /// <inheritdoc />
+        public byte[] GetContentBuffer(CodePages codepage)
+        {
+            return _barcode?.Build() ?? new byte[0];
+        }
+    }
+}


### PR DESCRIPTION
Barcodes are kind of inconvenient to use if you like to use the section builder. This change set
makes it so you can use barcodes like any other section. The one caveat is that since 2D barcodes
use different syntax between Phoenix and Reliance, we have to account for this in the TwoBarcode 
constructor with a flavor enum. Reasonable but not great.